### PR TITLE
Configure the period of time betweek token checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ expose a callback uri, and request an access token.
 It will then request user info (specified in the configuration) and add some header to let be used
 by your `upstream` service.
 
+The plugin will periodically check for token validity. You can configure the time period through
+a configuration parameter, in seconds.
+
 If configured, it can also check the provided email address and make sure it belongs to a particular
 domain, so you can use the plugin also for thirty party services.
 
@@ -60,6 +63,7 @@ $ curl -X POST http://kong:8001/apis/{api}/plugins \
 | `config.user_keys` <br /> <small>Optional</small>		| `username,email` | keys to extract from the `user_url` endpoint returned json, they will also be added to the headers of the upstream server as `X-OAUTH-XXX` |
 | `config.hosted_domain`  | | domain whose users must belong to in order to get logged in. Ignored if empty |
 | `config.email_key` 		  | | key to be checked for hosted domain, taken from userinfo endpoint |
+| `config.user_info_periodic_check` 		  | 60 | time in seconds between token checks |
 
 In addition to the `user_keys` will be added a `X-OAUTH-TOKEN` header with the access token of the provider.
 

--- a/src/access.lua
+++ b/src/access.lua
@@ -58,44 +58,52 @@ function _M.run(conf)
             end
 
             -- Get user info
-            -- TODO: don't know if makes sense to do everytime this call to check the validity of the token
-            --  or cache the result in a Cookie that expires early
-            local httpc = http:new()
-            local res, err = httpc:request_uri(conf.user_url, {
-                method = "GET",
-                ssl_verify = false,
-                headers = {
-                  ["Authorization"] = "Bearer " .. access_token,
-                }
-            })
+            if not ngx.var.cookie_EOAuthUserInfo then
+                local httpc = http:new()
+                local res, err = httpc:request_uri(conf.user_url, {
+                    method = "GET",
+                    ssl_verify = false,
+                    headers = {
+                      ["Authorization"] = "Bearer " .. access_token,
+                    }
+                })
 
-            if res then
-                -- redirect to auth if user result is invalid not 200
-                if res.status ~= 200 then
-                    return redirect_to_auth( conf, callback_url )
-                end
-
-                local json = cjson.decode(res.body)
-
-                if conf.hosted_domain ~= "" and conf.email_key ~= "" then
-                    if not pl_stringx.endswith(json[conf.email_key], conf.hosted_domain) then
-                        ngx.status = 401
-                        ngx.say("Hosted domain is not matching")
-                        ngx.exit(ngx.HTTP_OK)
-                        return
+                if res then
+                    -- redirect to auth if user result is invalid not 200
+                    if res.status ~= 200 then
+                        return redirect_to_auth( conf, callback_url )
                     end
-                end
 
-                for i, key in ipairs(conf.user_keys) do
-                    ngx.header["X-Oauth-".. key] = json[key]
+                    local json = cjson.decode(res.body)
+
+                    if conf.hosted_domain ~= "" and conf.email_key ~= "" then
+                        if not pl_stringx.endswith(json[conf.email_key], conf.hosted_domain) then
+                            ngx.status = 401
+                            ngx.say("Hosted domain is not matching")
+                            ngx.exit(ngx.HTTP_OK)
+                            return
+                        end
+                    end
+
+                    for i, key in ipairs(conf.user_keys) do
+                        ngx.header["X-Oauth-".. key] = json[key]
+                    end
+                    ngx.header["X-Oauth-Token"] = access_token
+
+                    if type(ngx.header["Set-Cookie"]) == "table" then
+                        ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0; Path=/;Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", unpack(ngx.header["Set-Cookie"]) }
+                    else
+                        ngx.header["Set-Cookie"] = { "EOAuthUserInfo=0; Path=/;Max-Age=" .. conf.user_info_periodic_check .. ";HttpOnly", ngx.header["Set-Cookie"] }
+                    end
+
+                else
+                    ngx.status = 500
+                    ngx.say(err)
+                    ngx.exit(ngx.HTTP_OK)
+                    return
                 end
-                ngx.header["X-Oauth-Token"] = access_token
-            else
-                ngx.status = 500
-                ngx.say(err)
-                ngx.exit(ngx.HTTP_OK)
-                return
             end
+
 
         else
             return redirect_to_auth( conf, callback_url )

--- a/src/access.lua
+++ b/src/access.lua
@@ -173,7 +173,7 @@ function  handle_callback( conf, callback_url )
         end
     else
         ngx.status = ngx.HTTP_BAD_REQUEST
-        ngx.say("Nope")
+        ngx.say("User has denied access to the resources.")
         ngx.exit(ngx.HTTP_OK)
     end
 end

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -21,6 +21,7 @@ return {
     client_secret = {type = "string", required = true},
     scope = {type = "string", default = ""},
     user_keys = {type = "array", default = {"username", "email"}},
+    user_info_periodic_check = {type = "number", required = true, default = 60},
     hosted_domain = {type = "string", default = ""},
     email_key = {type = "string", default = ""}
   }


### PR DESCRIPTION
The following PR will address and hopefully solve #5 

It is basically adding another parameter that will configure a Cookie; when this is expired, the user info endpoint will be called again to make sure the token is still valid.

I put 60 (seconds) as default as I think is a good value. Who's more obsessed about the security can definitely set this to 0 or 1, according to the `Max-Age` parameter.

I'd like to test these things, I still have to come out with a way to spin up a fake oauth2 server, though.

@mogui ^